### PR TITLE
rename and enhance clear() to dismiss(), return snack IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to **Whisper** will be documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org) and follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
+
+---
+
+## [0.1.1] - 2025-04-04
+
+### Added
+- `snackbar.promise(...)` now returns the original promise, allowing `.then()` or `await` chaining.
+- `snackbar.info`, `snackbar.success`, `snackbar.warning`, `snackbar.error`, and `snackbar(...)` now return the created snack's `id`.
+
+### Changed
+- Renamed `snackbar.clear()` to `snackbar.dismiss()` to better reflect its behavior and naming consistency.
+
+### Breaking Changes
+- ❗️`clear()` has been removed. Use `snackbar.dismiss(ids?: string[])` instead.
+  - Pass an array of snack IDs to dismiss specific ones.
+  - Call with no arguments to dismiss all active snacks.
+
+---
+
+## [0.1.0] - 2025-03-XX
+
+### Added
+- Initial release of Whisper – a stackable, customizable snackbar (toast) component using TailwindCSS and Framer Motion.
+- Supports snack types: `default`, `info`, `success`, `warning`, `error`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org) and follows th
 
 ---
 
-## [0.1.0] - 2025-03-XX
+## [0.1.0] - 2025-02-01
 
 ### Added
 - Initial release of Whisper – a stackable, customizable snackbar (toast) component using TailwindCSS and Framer Motion.

--- a/README.md
+++ b/README.md
@@ -97,11 +97,22 @@ snackbar.promise(promise(), {
 }
 ```
 
-## 🔮 Contribution
+## 🛠️ Contributing
 
-If you wish to contribute to this project, clone the repo and run it locally using 
+📦 [Changelog](./CHANGELOG.md)
+
+Pull requests are welcome! If you're adding a feature or fixing a bug, please keep the following in mind:
+
+- Keep it simple: Favor readability and simplicity over cleverness or complexity.
+
+- Readable & customizable: Code should be easy for others to understand and extend - Whisper is designed to be minimal and developer-friendly.
+
+- Consistency matters: Follow existing patterns and conventions where possible.
+
+- Type safety & clarity: Use clear, expressive types and avoid unnecessary abstractions.
+
+If you're unsure about something, feel free to open an issue or draft PR to discuss — happy to collaborate!
 
 ```
 npm run dev
 ```
-

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A lightweight and fully customizable React snackbar (toast) component built with
 
 - **Icon Support:** Built-in icons for different snack types and support for custom icons.
 
-- **Stackable Alerts:** Maintain a queue of snacks with a configurable max count (default: 6), and clear them all with a provided function.
+- **Stackable Alerts:** Maintain a queue of snacks with a configurable max count (default: 6), and dismiss them all with a provided function.
 
 - **WCAG Accessibility:** The default type styles adhere to WCAG AA guidelines.
 
@@ -71,7 +71,7 @@ snackbar.info("Your mission is to steal the Yaz Diamond");
 snackbar.success("You successfully snuck past security");
 snackbar.warning("You have 5m before the alarm is triggered");
 snackbar.error("Mission failed, you were spotted");
-snackbar.clear();
+snackbar.dismiss();
 
 const promise = () => new Promise((resolve) => setTimeout(() => resolve({ name: 'Whisper' }), 3000));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whisper",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/snackbar-context.tsx
+++ b/src/app/snackbar-context.tsx
@@ -50,17 +50,17 @@ interface PromiseSnackOptions {
   loading: { message: string, type?: SnackType, options?: SnackOptions },
   success: { message: string, type?: SnackType, options?: SnackOptions },
   error?: { message?: string, type?: SnackType, options?: SnackOptions },
-};
+}
 
 interface SnackbarContextType {
   snackbar: {
-    (_message: string, _options?: SnackOptions): void;
-    info: (_message: string, _options?: SnackOptions) => void;
-    success: (_message: string, _options?: SnackOptions) => void;
-    warning: (_message: string, _options?: SnackOptions) => void;
-    error: (_message: string, _options?: SnackOptions) => void;
+    (_message: string, _options?: SnackOptions): string;
+    info: (_message: string, _options?: SnackOptions) => string;
+    success: (_message: string, _options?: SnackOptions) => string;
+    warning: (_message: string, _options?: SnackOptions) => string;
+    error: (_message: string, _options?: SnackOptions) => string;
     promise: <T>(_promise: Promise<T>, _options: PromiseSnackOptions) => Promise<T>;
-    clear: () => void;
+    dismiss: (_ids?: string[]) => void;
   };
 }
 
@@ -98,7 +98,7 @@ export const SnackbarProvider = ({ children, maxSnacks = DEFAULT_MAX_SNACKS, pos
       setSnacks((prev) => positionIsTop ? [...prev, newSnack] : [newSnack, ...prev]);
       resetTimeout(id, duration);
 
-      return newSnack;
+      return id;
     }, [position, resetTimeout]);
 
   const snackbar = Object.assign(
@@ -110,7 +110,7 @@ export const SnackbarProvider = ({ children, maxSnacks = DEFAULT_MAX_SNACKS, pos
       error: (message: string, options?: SnackOptions) => createSnack(message, 'error', options),
       promise: async function <T>(promise: Promise<T>, options: PromiseSnackOptions): Promise<T> {
         const { loading, success, error } = options;
-        const { id } = createSnack(loading.message, loading.type ?? 'default', { icon: <Spinner />, ...loading.options, duration: 999999 });
+        const id = createSnack(loading.message, loading.type ?? 'default', { icon: <Spinner />, ...loading.options, duration: 999999 });
         try {
           const result = await promise;
           const type = success.type ?? 'success';
@@ -124,7 +124,9 @@ export const SnackbarProvider = ({ children, maxSnacks = DEFAULT_MAX_SNACKS, pos
           throw err;
         }
       },
-      clear: () => setSnacks([]),
+      dismiss: (ids?: string[]) => {
+        setSnacks((prev) => ids ? prev.filter((snack) => !ids.includes(snack.id)) : []);
+      },
     },
   );
 

--- a/src/app/snackbar-controls.tsx
+++ b/src/app/snackbar-controls.tsx
@@ -16,7 +16,7 @@ export const SnackbarControls = ({ onPositionChange }: { onPositionChange: (_pos
     { label: 'warning', code: `snackbar.warning("You have 5m before the alarm is triggered");`, onClick: () => snackbar.warning('You have 5m before the alarm is triggered') },
     { label: 'error', code: `snackbar.error("Mission failed, you were spotted");`, onClick: () => snackbar.error('Mission failed, you were spotted') },
     { label: 'promise', code: `const promise = () => new Promise((resolve) => setTimeout(() => resolve({ name: 'Whisper' }), 3000));\n\nsnackbar.promise(promise(), {\n\tloading: { message: 'On route to the police station...' },\n\tsuccess: {\n\t\tmessage: 'You have arrived at the police station',\n\t\toptions: { icon: <ShieldIcon />, duration: 3000 },\n\t},\n\terror: { message: 'The cruiser got a flat tire!' },\n});`, onClick: () => snackbar.promise(promise(), { loading: { message: 'On route to the police station...' }, success: { message: 'You have arrived at the police station', options: { icon: <ShieldIcon />, duration: 3000 } }, error: { message: 'The cruiser got a flat tire!' } }) },
-    { label: 'clear', code: `snackbar.clear();`, onClick: () => snackbar.clear() },
+    { label: 'dismiss', code: `snackbar.dismiss();`, onClick: () => snackbar.dismiss() },
   ];
 
   const options = [
@@ -33,7 +33,7 @@ export const SnackbarControls = ({ onPositionChange }: { onPositionChange: (_pos
 
   const handlePositionChange = useCallback((newPosition: Position) => {
     if (newPosition !== position) {
-      snackbar.clear();
+      snackbar.dismiss();
       setPosition(newPosition);
       onPositionChange(newPosition);
     }


### PR DESCRIPTION
✨ What’s Changed
- Renamed snackbar.clear() ➝ snackbar.dismiss()
  - Improves clarity and better reflects its purpose.
  - This method now accepts an optional array of snack IDs to dismiss specific snacks, or no argument to dismiss all.
- All snackbar creation methods now return the snack ID
  - This includes `snackbar(...)`, `snackbar.info`, `success`, `warning`, `error`.
  - Makes it easier to manually dismiss specific snacks later.
- Added a `CHANGELOG.md`
  - Follows [Keep a Changelog](https://keepachangelog.com/) format.
  - Documents this and past changes in a clear, versioned history.
---
💥 Breaking Changes
- `snackbar.clear()` has been removed
  - Please replace with `snackbar.dismiss()`
---
By the suggestion of @duckyfuz :)